### PR TITLE
feat(generateroutes.js): generate route param name dinamically 

### DIFF
--- a/src/generateRoutes.js
+++ b/src/generateRoutes.js
@@ -9,6 +9,9 @@ const generateRoutes = (routes, app, endpointInfo = false) => {
   routes.forEach(route => {
     info(`\n${route.name} endpoints`)
 
+    const entitySchemas = route.entity.id.prototype.meta.schema
+    const [idFieldName] = Object.entries(entitySchemas).find(([_key, value]) => value.options.isId)
+
     if (route.getAll) {
       const endpoint = `/${route.name}`
       info(`    GET ${endpoint} -> ${route.getAll.usecase().description}`)
@@ -22,7 +25,7 @@ const generateRoutes = (routes, app, endpointInfo = false) => {
     }
 
     if (route.getById) {
-      const endpoint = `/${route.name}/:${route.getById.id || 'id'}`
+      const endpoint = `/${route.name}/:${route.getById.id || idFieldName || route.idEntity}`
       info(`    GET ${endpoint} -> ${route.getById.usecase().description}`)
       app.get(endpoint, async (req, res, next) => {
         const request = { query: req.query, params: req.params }
@@ -46,7 +49,7 @@ const generateRoutes = (routes, app, endpointInfo = false) => {
     }
 
     if (route.put) {
-      const endpoint = `/${route.name}/:${route.put.id || 'id'}`
+      const endpoint = `/${route.name}/:${route.put.id || idFieldName || 'id'}`
       info(`    PUT ${endpoint} -> ${route.put.usecase().description}`)
       app.put(endpoint, async (req, res, next) => {
         const request = { body: req.body, params: req.params }
@@ -58,7 +61,7 @@ const generateRoutes = (routes, app, endpointInfo = false) => {
     }
 
     if (route.delete) {
-      const endpoint = `/${route.name}/:${route.delete.id || 'id'}`
+      const endpoint = `/${route.name}/:${route.delete.id || idFieldName || 'id'}`
       info(`    DELETE ${endpoint} -> ${route.delete.usecase().description}`)
       app.delete(endpoint, async (req, res, next) => {
         const request = { params: req.params }

--- a/test/generateRoutes.test.js
+++ b/test/generateRoutes.test.js
@@ -7,6 +7,20 @@ const express = require('express')
 const generateRoutes = require('../src/generateRoutes')
 
 describe('Herbs2Rest - Generate Routes', () => {
+  const entityTest = {
+    id : {
+      prototype: {
+        meta: {
+          schema: {
+            testId: {
+              name: 'testId',
+              options: {isId: true}
+            } 
+          }
+        }
+      }
+    }
+  }
   const usecaseTest = () =>
     usecase('Test usecase', {
       request: {},
@@ -22,6 +36,7 @@ describe('Herbs2Rest - Generate Routes', () => {
     const controllerList = [
       {
         name: 'lists',
+        entity : entityTest,
         getAll: { usecase: usecaseTest }
       },
     ]
@@ -43,6 +58,7 @@ describe('Herbs2Rest - Generate Routes', () => {
     const controllerList = [
       {
         name: 'lists',
+        entity : entityTest,
         getById: { usecase: usecaseTest }
       },
     ]
@@ -64,6 +80,7 @@ describe('Herbs2Rest - Generate Routes', () => {
     const controllerList = [
       {
         name: 'lists',
+        entity : entityTest,
         post: { usecase: usecaseTest }
       },
     ]
@@ -85,6 +102,7 @@ describe('Herbs2Rest - Generate Routes', () => {
     const controllerList = [
       {
         name: 'lists',
+        entity : entityTest,
         put: { usecase: usecaseTest }
       },
     ]
@@ -106,6 +124,7 @@ describe('Herbs2Rest - Generate Routes', () => {
     const controllerList = [
       {
         name: 'lists',
+        entity : entityTest,
         delete: { usecase: usecaseTest }
       },
     ]


### PR DESCRIPTION
feat(generateroutes.js): generate route param name dinamically with entity's id field name

![image](https://user-images.githubusercontent.com/99423701/175789201-16514a76-58ce-4614-af0c-f7c87129e204.png)

In the file generated by running the Herbs CLI, we inserted a entity parameter to export entity informations that is highlighted on the image above.