### PR TITLE
Usecase should have access to req.user inside ctx

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,33 @@ const testUseCase = (injection) =>
   })
 ```
 
+#### User
+
+All use cases receive the user that was passed in the request if they are using the default controller.
+
+Example:
+
+```javascript
+const { Ok, Err, usecase, step } = require('@herbsjs/buchu')
+
+const testUseCase = (injection) =>
+  usecase('Test UseCase', {
+    authorize: async (user) => {
+      if (user === 'admin')
+        return Ok()
+      else
+        return Err('Invalid user')
+    },
+
+    setup: ctx => (ctx.di = Object.assign({}, dependency, injection)),
+
+    'Print the user passed on request': step(ctx => {
+      console.log(ctx.di.user) // User passed in the request
+
+      return Ok()
+    }),
+  })
+
 ---
 
 #### Example

--- a/src/defaultController.js
+++ b/src/defaultController.js
@@ -3,7 +3,8 @@ const req2request = require('./helpers/req2request')
 
 const defaultController = async (usecase, req, user, res, next, methodName) => {
   try {
-    const ucInstance = usecase()
+    const injection = { user }
+    const ucInstance = usecase(injection)
 
     const hasAccess = await ucInstance.authorize(user)
 

--- a/test/defaultController.test.js
+++ b/test/defaultController.test.js
@@ -35,6 +35,30 @@ describe('Herbs2Rest - Default Controller', () => {
     assert.deepStrictEqual(res.statusCode, 200)
   })
 
+  it('Usecase should have access to user inside ctx', async () => {
+
+    const res = new Response()
+
+    const uc = (injection) =>
+      usecase('Usecase with User', {
+        request: {},
+        authorize: async () => Ok(),
+        setup: ctx => (ctx.di = Object.assign({}, injection)),
+        'Verify if the User is present': step((ctx) => ctx.ret = ctx.di.user)
+      })
+
+    const req = {}
+
+    const user = {
+      id: '101'
+    }
+
+    await defaultController(uc, req, user, res, () => { })
+
+    assert.deepStrictEqual(res.statusCode, 200)
+    assert.deepStrictEqual(res.data, user)
+  })
+
   it('Should not authorize usecase', async () => {
     // Given
     const res = new Response()
@@ -199,6 +223,5 @@ describe('Herbs2Rest - Default Controller', () => {
 
     assert.deepStrictEqual(res.statusCode, 500)
   })
-
 
 })


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Feature https://github.com/herbsjs/herbs2rest/issues/41

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Added injection in the defaultController function so that req.user data can be accessed within usecase steps through ctx.di

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request
- [x] Remember to check if code coverage decrease, if so, please implement the necessary tests

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
